### PR TITLE
Do not force commit access to members

### DIFF
--- a/OpenWrt Rules.md
+++ b/OpenWrt Rules.md
@@ -19,8 +19,7 @@ _**Membership**_
   
 _**Commit access**_
 
-* Active members have commit access to all repositories.
-  Inactive members and non-members do not.
+* Active members can request commit access to all repositories.
 * The commit credentials of inactive members are revoked.
   They will be restored upon their return to active status.
   


### PR DESCRIPTION
Allow to have members without commit access, but ebery member should have the right to request commit access.